### PR TITLE
Chamadas env() removidas

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Em config/services.php:
     'senhaunica' => [
         'client_id' => env('SENHAUNICA_KEY'),
         'client_secret' => env('SENHAUNICA_SECRET'),
+        'callback_id' => env('SENHAUNICA_CALLBACK_ID'),
          'redirect' => '/',
     ], 
 

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -1,6 +1,5 @@
 <?php
 
-//namespace SocialiteProviders\Senhaunica;
 namespace Uspdev\SenhaunicaSocialite;
 
 use SocialiteProviders\Manager\OAuth1\AbstractProvider;
@@ -12,7 +11,6 @@ class Provider extends AbstractProvider
      * Unique Provider Identifier.
      */
     const IDENTIFIER = 'SENHAUNICA';
-
 
     public function user()
     {
@@ -30,7 +28,6 @@ class Provider extends AbstractProvider
             'emailAlternativo'    => $user->emailAlternativo,
             'telefone'            => $user->telefone,
             'vinculo'             => $user->vinculo,
-            
         ])->setToken($token->getIdentifier(), $token->getSecret());
 
     }

--- a/src/SenhaunicaExtendSocialite.php
+++ b/src/SenhaunicaExtendSocialite.php
@@ -1,6 +1,5 @@
 <?php
 
-//namespace SocialiteProviders\Senhaunica;
 namespace Uspdev\SenhaunicaSocialite;
 
 use SocialiteProviders\Manager\SocialiteWasCalled;

--- a/src/Server.php
+++ b/src/Server.php
@@ -1,13 +1,11 @@
 <?php
 
-//namespace SocialiteProviders\Senhaunica;
 namespace Uspdev\SenhaunicaSocialite;
 
 use League\OAuth1\Client\Credentials\TokenCredentials;
 use SocialiteProviders\Manager\OAuth1\Server as BaseServer;
 use SocialiteProviders\Manager\OAuth1\User;
 
-//use League\OAuth1\Client\Credentials\CredentialsException;
 use League\OAuth1\Client\Credentials\TemporaryCredentials;
 
 class Server extends BaseServer
@@ -120,7 +118,7 @@ class Server extends BaseServer
             $temporaryIdentifier = $temporaryIdentifier->getIdentifier();
         }
 
-        $parameters = array('oauth_token' => $temporaryIdentifier,'callback_id' => env('SENHAUNICA_CALLBACK_ID'));
+        $parameters = array('oauth_token' => $temporaryIdentifier,'callback_id' => config('services.senhaunica.callback_id'));
 
         $url = $this->urlAuthorization();
         $queryString = http_build_query($parameters);


### PR DESCRIPTION
@girol, 

env() removido e testado. Neste caso foi simples pois o socialite já nos obriga a usar o config/services.php.

Documentação atualizada.

Você pode revisar e aprovar?

Fix #9 