### PR TITLE
corrigindo a issue #55

### DIFF
--- a/resources/views/partials/filterbox.blade.php
+++ b/resources/views/partials/filterbox.blade.php
@@ -9,7 +9,7 @@
     <input class="form-control form-control-sm" type="text" name="filter"
       placeholder="Filtrar..." id="dt-search" value="{{ $search['filter'] ?? '' }}">
     <div class="input-group-append">
-        <button class="btn btn-outline-secondary btn-sm">
+        <button class="btn btn-outline-secondary btn-sm" id="dt-search-button">
             <i class="fas fa-search"></i>
         </button>
     </div>
@@ -27,6 +27,12 @@
         $('#dt-search-clear').on('click', function() {
             $('#dt-search').val('').trigger('keyup');
             $('#dt-search').focus();
+        })
+
+        $('#dt-search-button').on('keypress', function(e) {
+            if(e.which === 13) {
+                $('#dt-search-button').click();
+            }
         })
 
     })

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -253,7 +253,7 @@ class UserController extends Controller
     {
         $this->authorize('admin');
         if (empty($request->filter)) {
-            return redirect()->route('senhaunica-users.index');
+            return redirect()->route(config('senhaunica.userRoutes') . '.index');
         }
 
         $users = User::query();

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -253,7 +253,7 @@ class UserController extends Controller
     {
         $this->authorize('admin');
         if (empty($request->filter)) {
-            return redirect()->route(config('senhaunica.userRoutes') . '.index');
+            return redirect()->route('senhaunica-users.index');
         }
 
         $users = User::query();


### PR DESCRIPTION
    - Ao clicar no botão para limpar o imput de busca estava ocorrendo o
      erro de rota "index" não encontrada. Isso era porque o usuário
      alterou a rota default no arquivo de configuração. Foi corrigido
      para pegar do arquivo de configuração;

    - Foi adicionado no javascript um outro método para fazer a busca
      quando o usuário digita o enter.

    fix #55;