### PR TITLE
Flexibilização do menu socialite

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -35,7 +35,7 @@ return [
     ],
 
     // Define o gate para a rota de busca de pessoas
-    'findUsersGate' => 'admin',
+    'findUsersGate' => env('SENHAUNICA_FINDUSERSGATE', 'admin'),
 
     // fim views internas
     // -----------------------------------------------------

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -39,7 +39,7 @@ class EventServiceProvider extends ServiceProvider
                         $itens[] = [
                             'text' => '<i class="fas fa-users-cog text-danger"></i>',
                             'url' => config('senhaunica.userRoutes'),
-                            'can' => 'admin',
+                            'can' => ($event->item['can'] ?? 'admin'),
                         ];
                     }
                     // mostrando o botão de loginas
@@ -47,7 +47,7 @@ class EventServiceProvider extends ServiceProvider
                         'text' => '<i class="fas fa-user-secret text-danger"></i>',
                         'title' => 'Assumir identidade',
                         'url' => route('SenhaunicaLoginAsForm'),
-                        'can' => 'admin',
+                        'can' => ($event->item['can'] ?? 'admin'),
                     ];
                     $event->item = $itens;
                 }


### PR DESCRIPTION
Permite maior flexibilização na configuração da ocultação do menu socialite.

Do jeito que estava, um usuário de perfil admin visualizava o menu socialite (relação de usuários e "Assumir identidade") mesmo que ele estivesse acessando o sistema com perfil não admin.

Com a alteração que fiz, podemos programar o sistema cliente (por exemplo, "chamados") para exibir o menu socialite somente quando o admin estiver com perfil admin. Para isso, no laravel-usp-theme.php do sistema cliente, coloca-se 'can' do menu socialite como 'perfiladmin', e o senhaunica-socialite lerá o 'can' do sistema cliente. Se não houver esse 'can' no sistema cliente, fica como sempre foi, fica como 'admin', não afetando os sistemas já existentes. Mas, se houver, leva ele em consideração.
