### PR TITLE
transfere do senhaunica-socialite para o sistema cliente a configuração do findusersgate

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -35,7 +35,7 @@ return [
     ],
 
     // Define o gate para a rota de busca de pessoas
-    'findUsersGate' => env('SENHAUNICA_FINDUSERSGATE', 'admin'),
+    'findUsersGate' => 'admin',
 
     // fim views internas
     // -----------------------------------------------------


### PR DESCRIPTION
Desfaz uma modificação recente que realizei. O Masaki apontou que é melhor manter a configuração do findusersgate no config.php ao invés de manter no .env do cliente. Essa configuração fica originalmente no config.php do senhaunica-socialite, mas, com a publicação do desse config, ele é copiado para o sistema cliente, então pode ser configurado diferentemente para cada sistema cliente.